### PR TITLE
Prepare for icon removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/buildexecutors/BuildExecutorsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/buildexecutors/BuildExecutorsWidget/index.jelly
@@ -22,11 +22,11 @@
                 <j:choose>
                     <j:when test="${c.offlineCause!=null and !c.connecting}">
                         (
-                        <img src="${imagesURL}/16x16/error.png" title="${c.offlineCause}"/>
+                        <l:icon class="icon-error icon-sm" title="${c.offlineCause}"/>
                         ${%offline})
                     </j:when>
                     <j:when test="${c.connecting}">
-                        (<img src="${imagesURL}/16x16/hourglass.gif"/>${%launching})
+                        (<l:icon class="icon-hourglass icon-sm"/>${%launching})
                     </j:when>
                     <j:otherwise>
                         (${%offline})


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778/`

Jenkins overrides icons in the order SVG -> PNG -> GIF, therefore modern Jenkins versions will display an SVG if available, older ones a PNG, and even older ones GIFs.

@hmarkc Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did